### PR TITLE
Unify debug output configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,37 @@ export const embedsConfig = {};
 #### Usercentrics
 
 
+### Debugging
+
+This library uses the `Debuggable` base class from [`@gebruederheitz/wp-frontend-utils`](https://www.npmjs.com/package/@gebruederheitz/wp-frontend-utils)
+to provide debug logging. Output is disabled by default, you can easily switch
+on logging detailed information to the browser console by using the provided
+toggle function:
+
+```js
+import { toggleDebugOutput } from '@gebruederheitz/consent-tools';
+
+// Logging for all modules on:
+toggleDebugOutput(true);
+
+// ...and off again
+toggleDebugOutput(false);
+```
+
+
+Additionally, most modules can be passed a `debug` key with a boolean value in
+their constructor options to toggle logging for just that module:
+
+```js
+new ElementsConsentManager(consentManager, {
+    debug: true,
+    // ...
+    embeds: embedsConfig,
+    reloadOnConsent: false,
+    clickOnConsent: true,
+});
+```
+
 
 ### Styling
 

--- a/src/get-gdpr-utils.js
+++ b/src/get-gdpr-utils.js
@@ -1,8 +1,9 @@
 import { EventEmitter2 } from 'eventemitter2';
+import { Debuggable } from '@gebruederheitz/wp-frontend-utils';
 
 import { WrappedGtmFactory } from './util/wrap-gtm';
 
-const debug = true;
+const debug = Debuggable.prototype.globalJsDebug;
 
 const gtmFactory = new WrappedGtmFactory(debug);
 const gtm = gtmFactory.getWrappedGtm();

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,11 @@ import { ModalGdprManager } from './modal-gdpr-manager';
 import { ConsentManager } from './consent-manager';
 import { ElementsConsentManager } from './elements-consent-manager';
 import { Usercentrics } from './usercentrics';
+import { Debuggable } from '@gebruederheitz/wp-frontend-utils';
+
+function toggleDebugOutput(toggle = true) {
+    Debuggable.prototype.globalJsDebug = toggle;
+}
 
 export {
     ConsentManager,
@@ -14,4 +19,5 @@ export {
     GdprIframeEmbed,
     ModalGdprManager,
     Usercentrics,
+    toggleDebugOutput,
 };

--- a/src/usercentrics.js
+++ b/src/usercentrics.js
@@ -1,6 +1,7 @@
 import { $$ } from '@gebruederheitz/wp-frontend-utils';
+import { Debuggable } from '@gebruederheitz/wp-frontend-utils';
 
-const debug = true;
+const debug = Debuggable.prototype.globalJsDebug;
 
 export class Usercentrics {
     static listen(selector = '') {

--- a/test/test-implementation.js
+++ b/test/test-implementation.js
@@ -7,49 +7,49 @@ import {
     // GdprIframeEmbed,
     // ModalGdprManager,
     // Usercentrics,
+    toggleDebugOutput,
 } from '../dist/index.mjs';
 
-import { eventProxy, gtm } from '../src/get-gdpr-utils';
+toggleDebugOutput(true);
 
-
-const embedsConfig = {
-    useUC: true,
-    types: {
-        'Test Service': {
-            ucConsentName: 'Test Service',
-            ucTemplateId: 'lgXw0VvDj',
-            providerDisplayName: 'Test Service',
-            checkboxProviderName: 'Salesforce Live Agent',
-            // skipCheckbox: true,
-            // modalOpenerButton: true,
-            titleText: 'Bitte stimmen sie der Nutzung des Test Service zu!',
+whenDomReady().then(async () => {
+    const embedsConfig = {
+        useUC: true,
+        types: {
+            'Test Service': {
+                ucConsentName: 'Test Service',
+                ucTemplateId: 'lgXw0VvDj',
+                providerDisplayName: 'Test Service',
+                checkboxProviderName: 'Salesforce Live Agent',
+                // skipCheckbox: true,
+                // modalOpenerButton: true,
+                titleText: 'Bitte stimmen sie der Nutzung des Test Service zu!',
+            },
         },
-    },
-    defaultTextContent:
-        'Um diesen Inhalt anzuzeigen, müssen Sie ihn durch Klick auf den Button aktivieren. Dadurch werden Informationen an den Diensteanbieter übermittelt und dort gespeichert. Mehr Informationen finden in der <a href="%privacyPolicyUrl%%privacyPolicySection%">Datenschutzerklärung</a>',
-    privacyPolicyUrl: '/privacy',
-};
+        defaultTextContent:
+            'Um diesen Inhalt anzuzeigen, müssen Sie ihn durch Klick auf den Button aktivieren. Dadurch werden Informationen an den Diensteanbieter übermittelt und dort gespeichert. Mehr Informationen finden in der <a href="%privacyPolicyUrl%%privacyPolicySection%">Datenschutzerklärung</a>',
+        privacyPolicyUrl: '/privacy',
+    };
 
-// Get detailed debugging output from the various modules
-const debug = true;
+    const { eventProxy, gtm } = await import('../src/get-gdpr-utils');
 
-// Conditionally execute scripts based on user consent to services
-const consentManager = new ConsentManager(
-    { embeds: embedsConfig, debug },
-    gtm,
-    eventProxy
-);
-new ElementsConsentManager(consentManager, {
-    embeds: embedsConfig,
-    debug,
-    reloadOnConsent: false,
-    clickOnConsent: true,
+    // Conditionally execute scripts based on user consent to services
+    const consentManager = new ConsentManager(
+        { embeds: embedsConfig },
+        gtm,
+        eventProxy
+    );
+    new ElementsConsentManager(consentManager, {
+        embeds: embedsConfig,
+        reloadOnConsent: false,
+        clickOnConsent: true,
+    });
+
+    new GdprEmbedFactory({}, consentManager);
+
+    function onConsentForService() {
+        console.log('User has given their consent for this service!');
+    }
+
+    consentManager.withConsent('Test Service', onConsentForService).then();
 });
-
-new GdprEmbedFactory({}, consentManager);
-
-function onConsentForService() {
-    console.log('User has given their consent for this service!');
-}
-
-consentManager.withConsent('Test Service', onConsentForService).then();


### PR DESCRIPTION
Closes #1

The static `Usercentrics` class and the `get-gdpr-utils` helper will be addressed in #2 and #8